### PR TITLE
Bug Fix: the duration should take days into account

### DIFF
--- a/pr-stats
+++ b/pr-stats
@@ -45,7 +45,7 @@ while url is not None:
 
         createDate = datetime.strptime(created, "%Y-%m-%dT%H:%M:%SZ")
         endDate = datetime.strptime(end, "%Y-%m-%dT%H:%M:%SZ")
-        duration = (endDate - createDate).seconds;
+        duration = (endDate - createDate).days*3600*24 + (endDate - createDate).seconds;
 
         if user in stats:
             stats[user].append(duration)


### PR DESCRIPTION
the diff.second only caculate the seconds of last day.
e.g. if the diff is "7 days, 00:10:00",  the diff.second == 600.
